### PR TITLE
feat: configure luigi vm with luigi docker image

### DIFF
--- a/conf/ansible/roles/luigid/tasks/main.yml
+++ b/conf/ansible/roles/luigid/tasks/main.yml
@@ -1,8 +1,23 @@
 ---
+- name: install dependencies
+  apt:
+    name:
+      - docker-compose
+    update_cache: yes
+
+- name: authenticate to artifact repo
+  expect:
+    command: gcloud auth configure-docker us-central1-docker.pkg.dev
+    responses:
+      Do you want to continue (Y/n)?: "y"
+    creates: /root/.docker/config.json
+
 - name: create directory for config
   file:
-    path: /opt/luigid
+    path: "{{ item }}"
     state: directory
+  with_items:
+    - /opt/luigid
 
 - name: copy files to remote
   copy:
@@ -11,3 +26,9 @@
   with_items:
     - opt/luigid/docker-compose.yml
     - opt/luigid/luigi.cfg
+
+- name: bring up containers
+  docker_compose:
+    project_src: /opt/luigid
+    pull: true
+    state: present

--- a/conf/terraform/luigi-scheduler.tf
+++ b/conf/terraform/luigi-scheduler.tf
@@ -6,6 +6,8 @@ resource "google_compute_instance" "luigi" {
   labels = {
     app = "luigi"
   }
+  allow_stopping_for_update = true
+
   boot_disk {
     initialize_params {
       image = "ubuntu-os-cloud/ubuntu-2204-lts"
@@ -21,6 +23,10 @@ resource "google_compute_instance" "luigi" {
   scheduling {
     automatic_restart  = true
     provisioning_model = "STANDARD"
+  }
+  service_account {
+    email  = data.google_compute_default_service_account.default.email
+    scopes = ["cloud-platform"]
   }
 }
 


### PR DESCRIPTION
This sets up the ansible in a way will deploy the luigi instance correctly. I want to eventually have this running with an oauth proxy so we expose the instance to the internet. We should be able to expose this internally, though we may have to enable a firewall rule of some kind.