### PR TITLE
 Add ansible role to bootstrap development machines with software 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,12 +6,12 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/psf/black
-    rev: 22.12.0
+    rev: 23.1.0
     hooks:
       - id: black
       - id: black-jupyter
   - repo: https://github.com/pycqa/isort
-    rev: 5.11.4
+    rev: 5.12.0
     hooks:
       - id: isort
         name: isort (python)

--- a/conf/ansible/README.md
+++ b/conf/ansible/README.md
@@ -3,10 +3,32 @@
 This directory contains ansible for configuring GCP resources.
 In particular, we provision a centralized scheduler for luigi so that we can parallelize tasks across multiple VMs.
 
+## installing ansible
+
+```bash
+pip3 install ansible google-auth
+
+# also make application default credentials are available
+gcloud auth application-default login
+```
+
+## configuring luigi
+
 ```bash
 ansible-inventory -i inventory.luigi.gcp.yml --graph
 ansible all -i inventory.luigi.gcp.yml -m ping
 ansible-playbook -i inventory.luigi.gcp.yml luigi.yml
+```
+
+## configuring a dev VM
+
+The instance must be tagged with `app: dev`.
+Running this ansible role will update all machines with `gh`, `sops`, and `tfenv`.
+
+```bash
+ansible-inventory -i inventory.dev.gcp.yml --graph
+ansible all -i inventory.dev.gcp.yml -m ping
+ansible-playbook -i inventory.dev.gcp.yml dev.yml
 ```
 
 ## links

--- a/conf/ansible/dev.yml
+++ b/conf/ansible/dev.yml
@@ -1,0 +1,4 @@
+- hosts: all
+  become: true
+  roles:
+    - dev

--- a/conf/ansible/inventory.dev.gcp.yml
+++ b/conf/ansible/inventory.dev.gcp.yml
@@ -1,0 +1,12 @@
+plugin: gcp_compute
+auth_kind: application
+projects:
+  - birdclef-2023
+regions:
+  - us-central1
+hostnames:
+  - name
+filters:
+  - labels.app=dev
+compose:
+  ansible_host: networkInterfaces[0].accessConfigs[0].natIP

--- a/conf/ansible/roles/dev/tasks/main.yml
+++ b/conf/ansible/roles/dev/tasks/main.yml
@@ -1,0 +1,50 @@
+---
+# NOTE: it might be better to build a packer image, but this will do too
+
+# https://github.com/cli/cli/blob/trunk/docs/install_linux.md
+- name: install gh tool
+  become: yes
+  block:
+    - name: download key and update apt repo for gh cli
+      apt_key:
+        url: https://cli.github.com/packages/githubcli-archive-keyring.gpg
+        state: present
+    - name: add gh cli apt repo
+      apt_repository:
+        repo: deb [arch=amd64] https://cli.github.com/packages stable main
+        state: present
+        filename: github-cli
+    - name: install gh cli
+      apt:
+        name: gh
+        state: present
+- name: install sops
+  become: yes
+  block:
+    - name: set sops version
+      set_fact:
+        sops_version: "3.7.3"
+    - name: download sops deb
+      get_url:
+        url: https://github.com/mozilla/sops/releases/download/v{{ sops_version }}/sops_{{ sops_version }}_amd64.deb
+        dest: /tmp/sops.deb
+    - name: install sops
+      apt:
+        deb: /tmp/sops.deb
+        state: present
+- name: install tfenv
+  become: yes
+  block:
+    - name: install tfenv
+      git:
+        repo: https://github.com/tfutils/tfenv.git
+        dest: /opt/tfenv
+        version: v3.0.0
+    - name: link tfenv to /usr/local/bin
+      file:
+        src: /opt/tfenv/bin/{{ item }}
+        dest: /usr/local/bin/{{ item }}
+        state: link
+      with_items:
+        - tfenv
+        - terraform


### PR DESCRIPTION
When setting up a new machine, it's useful to have gh, tfenv, and sops. This configures the machine with the dependencies to avoid having to download debs, cloning repos, etc. 