### PR TITLE
feat: add example of using the dataloader with transform

### DIFF
--- a/notebooks/acm-20230320-00-dataloader-example.ipynb
+++ b/notebooks/acm-20230320-00-dataloader-example.ipynb
@@ -1,0 +1,238 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2\n",
+    "%load_ext lab_black"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# dataloader example\n",
+    "\n",
+    "This notebook shows how to use the dataloader with the tensorflow library.\n",
+    "We should probably wrap this in a PyTorch datamodule at some point."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-03-21 05:13:35.516993: I tensorflow/core/platform/cpu_feature_guard.cc:193] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  AVX2 AVX512F AVX512_VNNI FMA\n",
+      "To enable them in other operations, rebuild TensorFlow with the appropriate compiler flags.\n",
+      "2023-03-21 05:13:35.635749: I tensorflow/core/util/port.cc:104] oneDNN custom operations are on. You may see slightly different numerical results due to floating-point round-off errors from different computation orders. To turn them off, set the environment variable `TF_ENABLE_ONEDNN_OPTS=0`.\n",
+      "2023-03-21 05:13:36.763723: W tensorflow/compiler/xla/stream_executor/platform/default/dso_loader.cc:64] Could not load dynamic library 'libnvinfer.so.7'; dlerror: libnvinfer.so.7: cannot open shared object file: No such file or directory\n",
+      "2023-03-21 05:13:36.763792: W tensorflow/compiler/xla/stream_executor/platform/default/dso_loader.cc:64] Could not load dynamic library 'libnvinfer_plugin.so.7'; dlerror: libnvinfer_plugin.so.7: cannot open shared object file: No such file or directory\n",
+      "2023-03-21 05:13:36.763798: W tensorflow/compiler/tf2tensorrt/utils/py_utils.cc:38] TF-TRT Warning: Cannot dlopen some TensorRT libraries. If you would like to use Nvidia GPU with TensorRT, please make sure the missing libraries mentioned above are installed properly.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "WARNING:tensorflow:SavedModel saved prior to TF 2.5 detected when loading Keras model. Please ensure that you are saving the model with model.save() or tf.keras.models.save_model(), *NOT* tf.saved_model.save(). To confirm, there should be a file named \"keras_metadata.pb\" in the SavedModel directory.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-03-21 05:13:37.702593: E tensorflow/compiler/xla/stream_executor/cuda/cuda_driver.cc:267] failed call to cuInit: CUDA_ERROR_NO_DEVICE: no CUDA-capable device is detected\n",
+      "2023-03-21 05:13:37.702622: I tensorflow/compiler/xla/stream_executor/cuda/cuda_diagnostics.cc:156] kernel driver does not appear to be running on this host (acmiyaguchi-dev): /proc/driver/nvidia/version does not exist\n",
+      "2023-03-21 05:13:37.702897: I tensorflow/core/platform/cpu_feature_guard.cc:193] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  AVX2 AVX512F AVX512_VNNI FMA\n",
+      "To enable them in other operations, rebuild TensorFlow with the appropriate compiler flags.\n",
+      "WARNING:absl:Importing a function (__inference_BLOCK_4-2_ACT_1_layer_call_and_return_conditional_losses_15267) with ops with unsaved custom gradients. Will likely fail if a gradient is requested.\n",
+      "WARNING:absl:Importing a function (__inference_BLOCK_4-3_ACT_1_layer_call_and_return_conditional_losses_33161) with ops with unsaved custom gradients. Will likely fail if a gradient is requested.\n",
+      "WARNING:absl:Importing a function (__inference_BLOCK_3-3_ACT_2_layer_call_and_return_conditional_losses_14525) with ops with unsaved custom gradients. Will likely fail if a gradient is requested.\n",
+      "WARNING:absl:Importing a function (__inference_BLOCK_3-4_ACT_1_layer_call_and_return_conditional_losses_14681) with ops with unsaved custom gradients. Will likely fail if a gradient is requested.\n",
+      "WARNING:absl:Importing a function (__inference_BLOCK_3-4_ACT_2_layer_call_and_return_conditional_losses_14723) with ops with unsaved custom gradients. Will likely fail if a gradient is requested.\n",
+      "WARNING:absl:Importing a function (__inference_BLOCK_3-2_ACT_2_layer_call_and_return_conditional_losses_14327) with ops with unsaved custom gradients. Will likely fail if a gradient is requested.\n",
+      "WARNING:absl:Importing a function (__inference_BLOCK_4-2_ACT_2_layer_call_and_return_conditional_losses_32783) with ops with unsaved custom gradients. Will likely fail if a gradient is requested.\n",
+      "WARNING:absl:Importing a function (__inference_BLOCK_2-4_ACT_1_layer_call_and_return_conditional_losses_13993) with ops with unsaved custom gradients. Will likely fail if a gradient is requested.\n",
+      "WARNING:absl:Importing a function (__inference_BLOCK_3-3_ACT_2_layer_call_and_return_conditional_losses_30727) with ops with unsaved custom gradients. Will likely fail if a gradient is requested.\n",
+      "WARNING:absl:Importing a function (__inference_BLOCK_3-5_SE_CONV_1_layer_call_and_return_conditional_losses_14953) with ops with unsaved custom gradients. Will likely fail if a gradient is requested.\n",
+      "WARNING:absl:Importing a function (__inference_BLOCK_1-3_ACT_1_layer_call_and_return_conditional_losses_28018) with ops with unsaved custom gradients. Will likely fail if a gradient is requested.\n",
+      "WARNING:absl:Importing a function (__inference_BLOCK_3-2_ACT_2_layer_call_and_return_conditional_losses_30210) with ops with unsaved custom gradients. Will likely fail if a gradient is requested.\n",
+      "WARNING:absl:Importing a function (__inference_BLOCK_2-1_ACT_1_layer_call_and_return_conditional_losses_13695) with ops with unsaved custom gradients. Will likely fail if a gradient is requested.\n",
+      "WARNING:absl:Importing a function (__inference_BLOCK_4-3_ACT_2_layer_call_and_return_conditional_losses_15507) with ops with unsaved custom gradients. Will likely fail if a gradient is requested.\n",
+      "WARNING:absl:Importing a function (__inference_BLOCK_3-2_SE_CONV_1_layer_call_and_return_conditional_losses_14359) with ops with unsaved custom gradients. Will likely fail if a gradient is requested.\n",
+      "WARNING:absl:Importing a function (__inference_model_layer_call_and_return_conditional_losses_25336) with ops with unsaved custom gradients. Will likely fail if a gradient is requested.\n",
+      "WARNING:absl:Importing a function (__inference_BLOCK_3-1_SE_CONV_1_layer_call_and_return_conditional_losses_29744) with ops with unsaved custom gradients. Will likely fail if a gradient is requested.\n",
+      "WARNING:absl:Importing a function (__inference_BLOCK_4-1_ACT_1_layer_call_and_return_conditional_losses_15077) with ops with unsaved custom gradients. Will likely fail if a gradient is requested.\n",
+      "WARNING:absl:Importing a function (__inference_basic_5289) with ops with unsaved custom gradients. Will likely fail if a gradient is requested.\n",
+      "WARNING:absl:Importing a function (__inference_BLOCK_4-4_ACT_1_layer_call_and_return_conditional_losses_33678) with ops with unsaved custom gradients. Will likely fail if a gradient is requested.\n",
+      "WARNING:absl:Importing a function (__inference_BLOCK_4-4_ACT_2_layer_call_and_return_conditional_losses_15705) with ops with unsaved custom gradients. Will likely fail if a gradient is requested.\n",
+      "WARNING:absl:Importing a function (__inference_BLOCK_4-4_SE_CONV_1_layer_call_and_return_conditional_losses_33856) with ops with unsaved custom gradients. Will likely fail if a gradient is requested.\n",
+      "WARNING:absl:Importing a function (__inference_BLOCK_4-2_SE_CONV_1_layer_call_and_return_conditional_losses_15341) with ops with unsaved custom gradients. Will likely fail if a gradient is requested.\n",
+      "WARNING:absl:Importing a function (__inference_BLOCK_1-3_ACT_1_layer_call_and_return_conditional_losses_13593) with ops with unsaved custom gradients. Will likely fail if a gradient is requested.\n",
+      "WARNING:absl:Importing a function (__inference_BLOCK_4-3_SE_CONV_1_layer_call_and_return_conditional_losses_15539) with ops with unsaved custom gradients. Will likely fail if a gradient is requested.\n",
+      "WARNING:absl:Importing a function (__inference__wrapped_model_7115) with ops with unsaved custom gradients. Will likely fail if a gradient is requested.\n",
+      "WARNING:absl:Importing a function (__inference_BLOCK_2-3_ACT_1_layer_call_and_return_conditional_losses_13891) with ops with unsaved custom gradients. Will likely fail if a gradient is requested.\n",
+      "WARNING:absl:Importing a function (__inference_BLOCK_4-1_ACT_2_layer_call_and_return_conditional_losses_32278) with ops with unsaved custom gradients. Will likely fail if a gradient is requested.\n",
+      "WARNING:absl:Importing a function (__inference_BLOCK_3-5_ACT_1_layer_call_and_return_conditional_losses_14879) with ops with unsaved custom gradients. Will likely fail if a gradient is requested.\n",
+      "WARNING:absl:Importing a function (__inference_BLOCK_4-3_ACT_1_layer_call_and_return_conditional_losses_15465) with ops with unsaved custom gradients. Will likely fail if a gradient is requested.\n",
+      "WARNING:absl:Importing a function (__inference_BLOCK_3-1_ACT_1_layer_call_and_return_conditional_losses_29566) with ops with unsaved custom gradients. Will likely fail if a gradient is requested.\n",
+      "WARNING:absl:Importing a function (__inference_BLOCK_1-2_ACT_1_layer_call_and_return_conditional_losses_27706) with ops with unsaved custom gradients. Will likely fail if a gradient is requested.\n",
+      "WARNING:absl:Importing a function (__inference_BLOCK_2-1_ACT_1_layer_call_and_return_conditional_losses_28330) with ops with unsaved custom gradients. Will likely fail if a gradient is requested.\n",
+      "WARNING:absl:Importing a function (__inference_BLOCK_4-1_ACT_2_layer_call_and_return_conditional_losses_15119) with ops with unsaved custom gradients. Will likely fail if a gradient is requested.\n",
+      "WARNING:absl:Importing a function (__inference_BLOCK_4-3_SE_CONV_1_layer_call_and_return_conditional_losses_33339) with ops with unsaved custom gradients. Will likely fail if a gradient is requested.\n",
+      "WARNING:absl:Importing a function (__inference_BLOCK_1-1_ACT_1_layer_call_and_return_conditional_losses_13397) with ops with unsaved custom gradients. Will likely fail if a gradient is requested.\n",
+      "WARNING:absl:Importing a function (__inference_BLOCK_4-1_ACT_1_layer_call_and_return_conditional_losses_32139) with ops with unsaved custom gradients. Will likely fail if a gradient is requested.\n",
+      "WARNING:absl:Importing a function (__inference_BLOCK_3-2_SE_CONV_1_layer_call_and_return_conditional_losses_30249) with ops with unsaved custom gradients. Will likely fail if a gradient is requested.\n",
+      "WARNING:absl:Importing a function (__inference_BLOCK_3-1_ACT_2_layer_call_and_return_conditional_losses_29705) with ops with unsaved custom gradients. Will likely fail if a gradient is requested.\n",
+      "WARNING:absl:Importing a function (__inference_BLOCK_3-1_SE_CONV_1_layer_call_and_return_conditional_losses_14169) with ops with unsaved custom gradients. Will likely fail if a gradient is requested.\n",
+      "WARNING:absl:Importing a function (__inference_BLOCK_3-5_ACT_2_layer_call_and_return_conditional_losses_31761) with ops with unsaved custom gradients. Will likely fail if a gradient is requested.\n",
+      "WARNING:absl:Importing a function (__inference_BLOCK_3-4_ACT_1_layer_call_and_return_conditional_losses_31105) with ops with unsaved custom gradients. Will likely fail if a gradient is requested.\n",
+      "WARNING:absl:Importing a function (__inference_BLOCK_2-2_ACT_1_layer_call_and_return_conditional_losses_28630) with ops with unsaved custom gradients. Will likely fail if a gradient is requested.\n",
+      "WARNING:absl:Importing a function (__inference_BLOCK_1-1_ACT_1_layer_call_and_return_conditional_losses_27406) with ops with unsaved custom gradients. Will likely fail if a gradient is requested.\n",
+      "WARNING:absl:Importing a function (__inference_BLOCK_3-2_ACT_1_layer_call_and_return_conditional_losses_30071) with ops with unsaved custom gradients. Will likely fail if a gradient is requested.\n",
+      "WARNING:absl:Importing a function (__inference_BLOCK_3-5_SE_CONV_1_layer_call_and_return_conditional_losses_31800) with ops with unsaved custom gradients. Will likely fail if a gradient is requested.\n",
+      "WARNING:absl:Importing a function (__inference_BLOCK_3-3_SE_CONV_1_layer_call_and_return_conditional_losses_14557) with ops with unsaved custom gradients. Will likely fail if a gradient is requested.\n",
+      "WARNING:absl:Importing a function (__inference_BLOCK_3-4_SE_CONV_1_layer_call_and_return_conditional_losses_14755) with ops with unsaved custom gradients. Will likely fail if a gradient is requested.\n",
+      "WARNING:absl:Importing a function (__inference_BLOCK_3-3_ACT_1_layer_call_and_return_conditional_losses_14483) with ops with unsaved custom gradients. Will likely fail if a gradient is requested.\n",
+      "WARNING:absl:Importing a function (__inference_BLOCK_4-4_ACT_1_layer_call_and_return_conditional_losses_15663) with ops with unsaved custom gradients. Will likely fail if a gradient is requested.\n",
+      "WARNING:absl:Importing a function (__inference_model_layer_call_and_return_conditional_losses_26662) with ops with unsaved custom gradients. Will likely fail if a gradient is requested.\n",
+      "WARNING:absl:Importing a function (__inference_BLOCK_4-2_ACT_1_layer_call_and_return_conditional_losses_32644) with ops with unsaved custom gradients. Will likely fail if a gradient is requested.\n",
+      "WARNING:absl:Importing a function (__inference_BLOCK_4-2_ACT_2_layer_call_and_return_conditional_losses_15309) with ops with unsaved custom gradients. Will likely fail if a gradient is requested.\n",
+      "WARNING:absl:Importing a function (__inference_BLOCK_3-3_ACT_1_layer_call_and_return_conditional_losses_30588) with ops with unsaved custom gradients. Will likely fail if a gradient is requested.\n",
+      "WARNING:absl:Importing a function (__inference_BLOCK_3-2_ACT_1_layer_call_and_return_conditional_losses_14285) with ops with unsaved custom gradients. Will likely fail if a gradient is requested.\n",
+      "WARNING:absl:Importing a function (__inference_BLOCK_3-4_ACT_2_layer_call_and_return_conditional_losses_31244) with ops with unsaved custom gradients. Will likely fail if a gradient is requested.\n",
+      "WARNING:absl:Importing a function (__inference_BLOCK_4-1_SE_CONV_1_layer_call_and_return_conditional_losses_15151) with ops with unsaved custom gradients. Will likely fail if a gradient is requested.\n",
+      "WARNING:absl:Importing a function (__inference_BLOCK_3-5_ACT_1_layer_call_and_return_conditional_losses_31622) with ops with unsaved custom gradients. Will likely fail if a gradient is requested.\n",
+      "WARNING:absl:Importing a function (__inference_BLOCK_1-2_ACT_1_layer_call_and_return_conditional_losses_13491) with ops with unsaved custom gradients. Will likely fail if a gradient is requested.\n",
+      "WARNING:absl:Importing a function (__inference_BLOCK_2-3_ACT_1_layer_call_and_return_conditional_losses_28942) with ops with unsaved custom gradients. Will likely fail if a gradient is requested.\n",
+      "WARNING:absl:Importing a function (__inference_BLOCK_2-4_ACT_1_layer_call_and_return_conditional_losses_29254) with ops with unsaved custom gradients. Will likely fail if a gradient is requested.\n",
+      "WARNING:absl:Importing a function (__inference_BLOCK_4-4_ACT_2_layer_call_and_return_conditional_losses_33817) with ops with unsaved custom gradients. Will likely fail if a gradient is requested.\n",
+      "WARNING:absl:Importing a function (__inference_BLOCK_4-3_ACT_2_layer_call_and_return_conditional_losses_33300) with ops with unsaved custom gradients. Will likely fail if a gradient is requested.\n",
+      "WARNING:absl:Importing a function (__inference_BLOCK_3-3_SE_CONV_1_layer_call_and_return_conditional_losses_30766) with ops with unsaved custom gradients. Will likely fail if a gradient is requested.\n",
+      "WARNING:absl:Importing a function (__inference_BLOCK_4-1_SE_CONV_1_layer_call_and_return_conditional_losses_32317) with ops with unsaved custom gradients. Will likely fail if a gradient is requested.\n",
+      "WARNING:absl:Importing a function (__inference_BLOCK_3-4_SE_CONV_1_layer_call_and_return_conditional_losses_31283) with ops with unsaved custom gradients. Will likely fail if a gradient is requested.\n",
+      "WARNING:absl:Importing a function (__inference_BLOCK_3-5_ACT_2_layer_call_and_return_conditional_losses_14921) with ops with unsaved custom gradients. Will likely fail if a gradient is requested.\n",
+      "WARNING:absl:Importing a function (__inference_BLOCK_2-2_ACT_1_layer_call_and_return_conditional_losses_13789) with ops with unsaved custom gradients. Will likely fail if a gradient is requested.\n",
+      "WARNING:absl:Importing a function (__inference_BLOCK_3-1_ACT_1_layer_call_and_return_conditional_losses_14095) with ops with unsaved custom gradients. Will likely fail if a gradient is requested.\n",
+      "WARNING:absl:Importing a function (__inference_BLOCK_3-1_ACT_2_layer_call_and_return_conditional_losses_14137) with ops with unsaved custom gradients. Will likely fail if a gradient is requested.\n",
+      "WARNING:absl:Importing a function (__inference_BLOCK_4-4_SE_CONV_1_layer_call_and_return_conditional_losses_15737) with ops with unsaved custom gradients. Will likely fail if a gradient is requested.\n",
+      "WARNING:absl:Importing a function (__inference_BLOCK_4-2_SE_CONV_1_layer_call_and_return_conditional_losses_32822) with ops with unsaved custom gradients. Will likely fail if a gradient is requested.\n"
+     ]
+    }
+   ],
+   "source": [
+    "from tensorflow import keras\n",
+    "\n",
+    "model_path = \"../vendor/BirdNET-Analyzer/checkpoints/V2.2/BirdNET_GLOBAL_3K_V2.2_Model/\"\n",
+    "keras_model = keras.models.load_model(model_path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(array([-2.8339085e-05, -3.2334145e-05, -2.6037342e-05, ...,\n",
+       "         5.1300867e-06,  1.7665586e-06, -7.7035065e-06], dtype=float32),\n",
+       " 48000)"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import librosa\n",
+    "\n",
+    "test_path = \"../data/raw/birdclef-2023/train_audio/palfly2/XC563813.ogg\"\n",
+    "y, sr = librosa.load(test_path, sr=48_000)\n",
+    "y, sr"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(array([[1.5712982 , 0.42635736, 1.0132436 , ..., 1.5472673 , 0.80867696,\n",
+       "         0.74898386],\n",
+       "        [1.5236511 , 0.5448162 , 0.609984  , ..., 0.8903057 , 0.68575984,\n",
+       "         0.5812848 ],\n",
+       "        [1.3799995 , 0.5603645 , 0.5621645 , ..., 0.77269024, 0.5598088 ,\n",
+       "         0.35564625],\n",
+       "        ...,\n",
+       "        [1.6219438 , 0.615823  , 0.8171584 , ..., 0.9147644 , 1.0211197 ,\n",
+       "         1.2703916 ],\n",
+       "        [1.2679403 , 0.42659807, 0.71017295, ..., 0.6935778 , 0.68383   ,\n",
+       "         0.8716263 ],\n",
+       "        [1.4103328 , 0.41387966, 1.2248114 , ..., 0.75333804, 0.6153552 ,\n",
+       "         0.7482261 ]], dtype=float32),\n",
+       " (10, 320))"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from birdclef.data.datasets import AudioPCMDataSet\n",
+    "from birdclef.data.transforms import ToBirdNETEmbedding\n",
+    "\n",
+    "audio_path = \"../data/raw/birdclef-2023/train_audio\"\n",
+    "\n",
+    "dataset = AudioPCMDataSet(\n",
+    "    audio_path,\n",
+    "    # duration of the clip in seconds\n",
+    "    min_duration=10,\n",
+    "    # how much to slide between consecutive sequence elements\n",
+    "    window_step=1,\n",
+    "    # how much to slide between consecutive sequences\n",
+    "    seq_step=5,\n",
+    "    # transforms (in particular, to the embedding space)\n",
+    "    transforms=[ToBirdNETEmbedding(model=keras_model.model)],\n",
+    ")\n",
+    "batch = next(iter(dataset))\n",
+    "batch, batch.shape"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.6"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tests/data/test_datasets.py
+++ b/tests/data/test_datasets.py
@@ -1,6 +1,8 @@
 import pytest
+from tensorflow import keras
 
 from birdclef.data.datasets import AudioPCMDataSet
+from birdclef.data.transforms import ToBirdNETEmbedding
 
 
 @pytest.mark.parametrize(
@@ -15,3 +17,19 @@ def test_audio_pcm_dataset_loads_audio(train_audio, duration, step):
 
     row = next(iter(ds))
     assert row.shape == (duration // step, sample_rate * 3), "dimensions are incorrect"
+
+
+def test_train_audio_dataset_with_transforms(train_audio, birdnet_model_path):
+    sample_rate = 48_000
+    ds = AudioPCMDataSet(
+        train_audio,
+        sample_rate=sample_rate,
+        min_duration=10,
+        window_step=1,
+        transforms=[
+            ToBirdNETEmbedding(keras.models.load_model(birdnet_model_path)),
+        ],
+    )
+
+    row = next(iter(ds))
+    assert row.shape == (10, 320), "dimensions are incorrect"


### PR DESCRIPTION
Here's a notebook that shows an example of how you can use the dataloader to generate sequences of embeddings from a folder full of audio. Note that there's a `ToFloatTensor` transform in the modules too, but this hasn't been tested yet.